### PR TITLE
Repeated start for linux

### DIFF
--- a/adafruit_mpl3115a2.py
+++ b/adafruit_mpl3115a2.py
@@ -139,9 +139,7 @@ class MPL3115A2:
         if count is None:
             count = len(buf)
         with self._device as i2c:
-            buf[0] = address & 0xFF
-            i2c.write(buf, end=1, stop=False)
-            i2c.readinto(buf, end=count)
+            i2c.write_then_readinto(bytes([address & 0xFF]), buf, in_end=count, stop=False)
 
     def _read_u8(self, address):
         # Read an 8-bit unsigned value from the specified 8-bit address.


### PR DESCRIPTION
Possible fix for #6

Simple update to I2C calls for repeated start on Linux. Seemed to work OK using default 100kHz baud rate on I2C bus.
```console
pi@raspberrypi:~ $ python3 mpl3115a2_simpletest.py 
Pressure: 100859.000 pascals
Altitude: 114.689 meters
Temperature: 19.000 degrees Celsius
Pressure: 100859.250 pascals
Altitude: 114.877 meters
Temperature: 19.000 degrees Celsius
```

And still works OK on native CP.
```python
Adafruit CircuitPython 4.0.1 on 2019-05-22; Adafruit Metro M4 Express with samd51j19
>>> import mpl3115a2_simpletest
Pressure: 100857.246 pascals
Altitude: 114.439 meters
Temperature: 19.000 degrees Celsius
Pressure: 100855.243 pascals
Altitude: 114.939 meters
Temperature: 18.938 degrees Celsius
```